### PR TITLE
Shared informer race

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -251,3 +251,15 @@ func TestResyncCheckPeriod(t *testing.T) {
 		t.Errorf("expected %d, got %d", e, a)
 	}
 }
+
+// verify that https://github.com/kubernetes/kubernetes/issues/59822 is fixed
+func TestSharedInformerInitializationRace(t *testing.T) {
+	source := fcache.NewFakeControllerSource()
+	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
+	listener := newTestListener("raceListener", 0)
+
+	stop := make(chan struct{})
+	go informer.AddEventHandlerWithResyncPeriod(listener, listener.resyncPeriod)
+	go informer.Run(stop)
+	close(stop)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This fixes a race condition that can occur in the sharedIndexInformer, backported from the [PR](https://github.com/kubernetes/kubernetes/pull/59828)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#59822](https://github.com/kubernetes/kubernetes/issues/59822)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a race condition in k8s.io/client-go/tools/cache.SharedInformer that could violate the sequential delivery guarantee and cause panics on shutdown.
```
