### PR TITLE
Added missing error check that could cause kubelet to crash

### DIFF
--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -176,9 +176,11 @@ func (prober *flexVolumeProber) updateProbeNeeded() {
 // on its parent directory.
 func (prober *flexVolumeProber) addWatchRecursive(filename string) error {
 	addWatch := func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			if err := prober.watcher.AddWatch(path); err != nil {
-				glog.Errorf("Error recursively adding watch: %v", err)
+		if err == nil {
+			if info.IsDir() {
+				if err := prober.watcher.AddWatch(path); err != nil {
+					glog.Errorf("Error recursively adding watch: %v", err)
+				}
 			}
 		}
 		return nil

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -176,11 +176,9 @@ func (prober *flexVolumeProber) updateProbeNeeded() {
 // on its parent directory.
 func (prober *flexVolumeProber) addWatchRecursive(filename string) error {
 	addWatch := func(path string, info os.FileInfo, err error) error {
-		if err == nil {
-			if info.IsDir() {
-				if err := prober.watcher.AddWatch(path); err != nil {
-					glog.Errorf("Error recursively adding watch: %v", err)
-				}
+		if err == nil && info.IsDir() {
+			if err := prober.watcher.AddWatch(path); err != nil {
+				glog.Errorf("Error recursively adding watch: %v", err)
 			}
 		}
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds missing error check. An error can happen due to a race condition when watched files change, or become inaccessible. This can happen if a file was added to the driver directory then quickly removed, in which case the callback will be called with non-nil err and nil info, which is not checked, causing kubelet to crash.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#60861](https://github.com/kubernetes/kubernetes/issues/60861)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing error checking that could cause kubelet to crash in a race condition.
```
