### PR TITLE
fix nsenter GetFileType issue in containerized kubelet

### DIFF
--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -235,8 +235,13 @@ func (n *NsenterMounter) MakeRShared(path string) error {
 
 func (mounter *NsenterMounter) GetFileType(pathname string) (FileType, error) {
 	var pathType FileType
-	outputBytes, err := mounter.ne.Exec("stat", []string{"-L", `--printf "%F"`, pathname}).CombinedOutput()
+	outputBytes, err := mounter.ne.Exec("stat", []string{"-L", "--printf=%F", pathname}).CombinedOutput()
 	if err != nil {
+		if strings.Contains(string(outputBytes), "No such file") {
+			err = fmt.Errorf("%s does not exist", pathname)
+		} else {
+			err = fmt.Errorf("stat %s error: %v", pathname, string(outputBytes))
+		}
 		return pathType, err
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
UnmountDevice would fail in containerized kubelet in v1.9.x, and in the end, pod with volume mount could not be scheduled from one node to another since the original volume will never be released. This PR fixed this issue.

In nsenter_mount.GetFileType func, return error of following code will be different than mount_linux.GetFileType func
```
outputBytes, err := mounter.ne.Exec("stat", []string{"-L", `--printf "%F"`, pathname}).CombinedOutput()
```
Return error and output would be like following in nsenter_mount.GetFileType func:
error: `exit status 1`
output: `/usr/bin/stat: cannot stat '2': No such file or directory`

This PR makes the return error consistent as mount_linux.GetFileType func, and finally makes isDeviceOpened func work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#62282](https://github.com/kubernetes/kubernetes/issues/62282)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix nsenter GetFileType issue in containerized kubelet
```
