### PR TITLE
kubeadm: skip cgroup v2 preflight checks (AIT-70833)

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -49,7 +49,6 @@ func (mc MemCheck) Check() (warnings, errorList []error) {
 func addOSValidator(validators []system.Validator, reporter *system.StreamReporter, kubeletVersion string) []system.Validator {
 	validators = append(validators,
 		&system.OSValidator{Reporter: reporter},
-		&system.CgroupsValidator{Reporter: reporter, KubeletVersion: kubeletVersion},
 	)
 	return validators
 }
@@ -71,7 +70,6 @@ func addIPv4Checks(checks []Checker) []Checker {
 
 // addSwapCheck adds a swap check
 func addSwapCheck(checks []Checker) []Checker {
-	checks = append(checks, SwapCheck{})
 	return checks
 }
 


### PR DESCRIPTION
## Summary
- Stop kubeadm Linux preflight from adding the system cgroup validator.
- Stop kubeadm Linux preflight from adding the swap check that warns about cgroup v2.

## Test Plan
- go test ./cmd/kubeadm/app/preflight
- git diff --check
